### PR TITLE
fix: handle analytics URLs without host

### DIFF
--- a/assets/js/app.ts
+++ b/assets/js/app.ts
@@ -27,7 +27,13 @@ recordPageview()
 const trackAnchor = (element: HTMLAnchorElement): undefined => {
   element.addEventListener('click', event => {
     const analyticsUrl = new URL('https://exlytics.corybuecker.com')
-    const linkUrl = new URL(event.target.getAttribute("href"))
+    const href = event.target.getAttribute("href")
+    let linkUrl
+    if (href.startsWith("/")) {
+      linkUrl = URL.parse(`${window.location.host}${href}`)
+    } else {
+      linkUrl = URL.parse(href)
+    }
     const data = {
       path: linkUrl.pathname,
       host: linkUrl.host,

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     metadata:
       labels:
         app: blog
-        version: "1740939876"
+        version: "1741090063"
     spec:
       containers:
       - name: blog


### PR DESCRIPTION
closes #585