### PR TITLE
feat: major version bump with build optimizations and k8s config changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "blog"
-version = "1.2.0-dev"
+version = "2.0.0-dev"
 dependencies = [
  "anyhow",
  "axum",
@@ -254,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.6.4"
+version = "3.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61138465baf186c63e8d9b6b613b508cd832cba4ce93cf37ce5f096f91ac1a6"
+checksum = "33d9ef19ae5263a138da9a86871eca537478ab0332a7770bac7e3f08b801f89f"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.6.4"
+version = "3.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40d1dad34aa19bf02295382f08d9bc40651585bd497266831d40ee6296fb49ca"
+checksum = "577ae008f2ca11ca7641bd44601002ee5ab49ef0af64846ce1ab6057218a5cc1"
 dependencies = [
  "darling",
  "ident_case",
@@ -310,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.29"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "shlex",
 ]
@@ -487,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "a79c4acb1fd5fa3d9304be4c76e031c54d2e92d172a393e24b19a14fe8532fe9"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -497,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "74875de90daf30eb59609910b84d4d368103aaec4c924824c6799b28f77d6a1d"
 dependencies = [
  "fnv",
  "ident_case",
@@ -511,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "e79f8e61677d5df9167cd85265f8e5f64b215cdea3fb55eebc3e622e44c7a146"
 dependencies = [
  "darling_core",
  "quote",
@@ -1692,7 +1692,7 @@ dependencies = [
 [[package]]
 name = "rust-web-common"
 version = "0.1.0"
-source = "git+https://github.com/corybuecker/rust-web-common?branch=main#6cae044b87b3e6512e25ac0346286b3754cffb77"
+source = "git+https://github.com/corybuecker/rust-web-common?branch=main#ec860542906f84132754ea419255a2c1b0b58566"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -1765,9 +1765,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blog"
-version = "1.2.0-dev"
+version = "2.0.0-dev"
 edition = "2024"
 
 [dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,9 @@ COPY js /assets/js
 COPY templates /assets/templates
 WORKDIR /assets
 RUN npm install
-RUN npx tailwindcss -i css/app.css -o app.css
-RUN npx esbuild --sourcemap --bundle --format=esm --outdir=/assets js/app.ts
+RUN npx tailwindcss --minify --input css/app.css --output app.css
+RUN npx esbuild --sourcemap --minify --bundle --format=esm --outdir=/assets js/app.ts
+RUN gzip -k9 app.css app.js app.js.map
 
 FROM debian@sha256:d42b86d7e24d78a33edcf1ef4f65a20e34acb1e1abd53cabc3f7cdf769fc4082
 RUN mkdir -p /opt/blog
@@ -27,6 +28,6 @@ COPY --from=backend_builder /build/blog /opt/blog/
 COPY static /opt/blog/static
 COPY content /opt/blog/content
 COPY templates /opt/blog/templates
-COPY --from=frontend_builder /assets/app.css /assets/app.js /assets/app.js.map /opt/blog/static/
+COPY --from=frontend_builder /assets/app.css /assets/app.js /assets/app.js.map /assets/app.css.gz /assets/app.js.gz /assets/app.js.map.gz /opt/blog/static/
 USER 1000
 ENTRYPOINT ["/opt/blog/blog"]

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -12,7 +12,3 @@ services:
     ports:
       - 16686:16686
       - 4318:4318
-  grafana:
-    image: grafana/grafana@sha256:52c3e20686b860c6dc1f623811565773cf51eefa378817a4896dfc863c3c82c8 # 11.6.1
-    ports:
-      - 3000:3000

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
             - name: http
               containerPort: 8000
           envFrom:
-            - secretRef:
+            - configMapRef:
                 name: blog
           resources:
             limits:

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 images:
   - name: blog
     newName: ghcr.io/corybuecker/blog
-    digest: sha256:7f7d847cb91d59780a75f8ac4d71e3652c139f4c8406551efe0e9bbe7fa71fd1
+    digest: sha256:bbd39269bbba7c00abf1c09e07022cf807ea743b7d7442e4a83c0d88b308fdc7
 
 resources:
   - namespace.yaml
@@ -12,8 +12,10 @@ resources:
   - service.yaml
   - httproute.yaml
 
-secretGenerator:
+configMapGenerator:
   - name: blog
     namespace: blog
-    envs:
-      - .env
+    literals:
+      - LOG_LEVEL=debug
+      - METRICS_ENDPOINT=http://prometheus.prometheus.svc.cluster.local:9090/api/v1/otlp/v1/metrics
+      - TRACING_ENDPOINT=http://jaeger.jaeger.svc.cluster.local:4318/v1/traces


### PR DESCRIPTION
- Bump version to 2.0.0-dev
- Add asset minification and gzip compression in Docker build
- Replace Kubernetes secrets with configmap for environment variables
- Simplify telemetry initialization and add precompressed static file serving
- Update dependencies (bon, cc, darling, serde_json, rust-web-common)
- Remove Grafana from dev docker-compose setup