### PR TITLE
feat: enhance security and high availability

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: blog
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: blog

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -4,13 +4,14 @@ kind: Kustomization
 images:
   - name: blog
     newName: ghcr.io/corybuecker/blog
-    digest: sha256:bbd39269bbba7c00abf1c09e07022cf807ea743b7d7442e4a83c0d88b308fdc7
+    digest: sha256:faf199c049792c6868af21a8e55dbaa71ac454c31162908b5c9b6e1b95ae2592
 
 resources:
   - namespace.yaml
   - deployment.yaml
   - service.yaml
   - httproute.yaml
+  - pod_disruption_budget.yaml
 
 configMapGenerator:
   - name: blog

--- a/k8s/pod_disruption_budget.yaml
+++ b/k8s/pod_disruption_budget.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: blog
+  namespace: blog
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: blog

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ async fn secure_headers(request: Request, next: Next) -> impl IntoResponse {
     headers.insert(
         CONTENT_SECURITY_POLICY,
         HeaderValue::from_static(
-            "default-src 'none'; style-src 'self'; script-src 'self'; img-src 'self';",
+            "default-src 'none'; style-src 'self'; script-src 'self'; img-src 'self'; frame-ancestors 'none'; require-trusted-types-for 'script'",
         ),
     );
 


### PR DESCRIPTION
- Add frame-ancestors 'none' to CSP to prevent clickjacking attacks
- Add require-trusted-types-for 'script' CSP directive for XSS protection
- Scale deployment to 2 replicas for better availability
- Add PodDisruptionBudget to maintain minimum availability during updates
- Update container image digest